### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cordova/Phonegap bindings for Cashfree's SDKs
+# DEPRECATED
 
-Official Cordova/Phonegap plugin for integrating Cashfree's checkout.
+Please check https://www.npmjs.com/package/cashfree_pg_sdk_cordova for the Cashfree Cordova plugin. This plugin has been deprecated.
 
 ## Supported platforms
 


### PR DESCRIPTION
Deprecating this plugin as new Cashfree plugin is hosted in npm.